### PR TITLE
Add support for RSA-OAEP decryption

### DIFF
--- a/decrypt.go
+++ b/decrypt.go
@@ -42,7 +42,6 @@ func (p7 *PKCS7) Decrypt(cert *x509.Certificate, pkey crypto.PrivateKey) ([]byte
 	switch pkey := pkey.(type) {
 	case crypto.Decrypter:
 		var opts crypto.DecrypterOpts = nil
-		// TODO: there are more encryption OAEP encryption schemes to support (with hashes etc.) in the switch
 		switch algorithm := recipient.KeyEncryptionAlgorithm.Algorithm; {
 		case algorithm.Equal(OIDEncryptionAlgorithmRSAESOAEP):
 			var hashFunc crypto.Hash
@@ -51,8 +50,18 @@ func (p7 *PKCS7) Decrypt(cert *x509.Certificate, pkey crypto.PrivateKey) ([]byte
 				return nil, fmt.Errorf("pkcs7: %w", err)
 			}
 			opts = &rsa.OAEPOptions{Hash: hashFunc}
+		case algorithm.Equal(OIDEncryptionAlgorithmRSAMD5):
+			opts = &rsa.OAEPOptions{Hash: crypto.MD5}
+		case algorithm.Equal(OIDEncryptionAlgorithmRSASHA1):
+			opts = &rsa.OAEPOptions{Hash: crypto.SHA1}
+		case algorithm.Equal(OIDEncryptionAlgorithmRSASHA256):
+			opts = &rsa.OAEPOptions{Hash: crypto.SHA256}
+		case algorithm.Equal(OIDEncryptionAlgorithmRSASHA384):
+			opts = &rsa.OAEPOptions{Hash: crypto.SHA384}
+		case algorithm.Equal(OIDEncryptionAlgorithmRSASHA512):
+			opts = &rsa.OAEPOptions{Hash: crypto.SHA512}
 		case algorithm.Equal(OIDEncryptionAlgorithmRSA):
-			// nothing to do
+			// not an RSA-OAEP variant; no need to set `opts`.
 		default:
 			return nil, ErrUnsupportedAlgorithm
 		}

--- a/decrypt.go
+++ b/decrypt.go
@@ -47,7 +47,7 @@ func (p7 *PKCS7) Decrypt(cert *x509.Certificate, pkey crypto.PrivateKey) ([]byte
 			var hashFunc crypto.Hash
 			hashFunc, err := getHashFuncForKeyEncryptionAlgorithm(recipient.KeyEncryptionAlgorithm)
 			if err != nil {
-				return nil, fmt.Errorf("pkcs7: %w", err)
+				return nil, err
 			}
 			opts = &rsa.OAEPOptions{Hash: hashFunc}
 		case algorithm.Equal(OIDEncryptionAlgorithmRSAMD5):
@@ -80,7 +80,7 @@ func getHashFuncForKeyEncryptionAlgorithm(keyEncryptionAlgorithm pkix.AlgorithmI
 	var rest []byte
 	rest, err := asn1.Unmarshal(keyEncryptionAlgorithm.Parameters.FullBytes, params)
 	if err != nil {
-		return invalidHashFunc, fmt.Errorf("failed unmarshaling key encryption algorithm parameters: %w", err)
+		return invalidHashFunc, fmt.Errorf("failed unmarshaling key encryption algorithm parameters: %s", err.Error())
 	}
 	if len(rest) != 0 {
 		return invalidHashFunc, errors.New("trailing data after RSAES-OAEP parameters")

--- a/decrypt_test.go
+++ b/decrypt_test.go
@@ -7,16 +7,30 @@ import (
 
 func TestDecrypt(t *testing.T) {
 	tests := []struct {
-		name      string
-		algorithm string
-		hashFunc  string
-		fixture   string
-		expected  []byte
+		name     string
+		fixture  string
+		expected string
 	}{
-		{name: "rsa-pkcs-#1-v1.5/1", algorithm: "RSA PKCS #1 v1.5", fixture: EncryptedTestFixture, expected: []byte("This is a test")},
-		{name: "rsa-pkcs-#1-v1.5/2", algorithm: "RSA PKCS #1 v1.5", fixture: RSAPKCS1v15EncryptedTestFixture, expected: []byte("This is a test")},
-		{name: "rsa-oaep-sha1", algorithm: "RSA-OAEP", hashFunc: "SHA-1", fixture: RSAOAEPSHA1EncryptedTestFixture, expected: []byte("This is a test")},
-		{name: "rsa-oaep-sha256", algorithm: "RSA-OAEP", hashFunc: "SHA-256", fixture: RSAOAEPSHA256EncryptedTestFixture, expected: []byte("This is a test")},
+		{
+			name:     "rsa-pkcs-#1-v1.5/1",
+			fixture:  EncryptedTestFixture,
+			expected: "This is a test",
+		},
+		{
+			name:     "rsa-pkcs-#1-v1.5/2",
+			fixture:  RSAPKCS1v15EncryptedTestFixture,
+			expected: "This is a test",
+		},
+		{
+			name:     "rsa-oaep-sha1",
+			fixture:  RSAOAEPSHA1EncryptedTestFixture,
+			expected: "This is a test",
+		},
+		{
+			name:     "rsa-oaep-sha256",
+			fixture:  RSAOAEPSHA256EncryptedTestFixture,
+			expected: "This is a test",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -27,14 +41,18 @@ func TestDecrypt(t *testing.T) {
 			}
 			content, err := p7.Decrypt(fixture.Certificate, fixture.PrivateKey)
 			if err != nil {
-				t.Errorf("algorithm name: %s, hash function: %s: cannot Decrypt with error: %v", tt.algorithm, tt.hashFunc, err)
+				t.Errorf("cannot Decrypt with error: %v", err)
 			}
-			if !bytes.Equal(content, tt.expected) {
-				t.Errorf("algorithm name: %s, hash function: %s: decrypted result does not match.\n\tExpected:%s\n\tActual:%s", tt.algorithm, tt.hashFunc, tt.expected, content)
+			if !bytes.Equal(content, []byte(tt.expected)) {
+				t.Errorf("decrypted result does not match.\n\tExpected:%s\n\tActual:%s", []byte(tt.expected), content)
 			}
 		})
 	}
 }
+
+// TODO: use `embed` (after upping Go to at least 1.16), so that
+// it's easier to work with the files used to generate the below
+// test fixtures.
 
 // echo -n "This is a test" > test.txt
 // openssl cms -encrypt -in test.txt cert.pem

--- a/decrypt_test.go
+++ b/decrypt_test.go
@@ -5,20 +5,33 @@ import (
 	"testing"
 )
 
+type testDecryptStruct struct {
+	name, algorithmName, hashFunc, testFixture string
+}
+
 func TestDecrypt(t *testing.T) {
-	fixture := UnmarshalTestFixture(EncryptedTestFixture)
-	p7, err := Parse(fixture.Input)
-	if err != nil {
-		t.Fatal(err)
+	for i, test := range testDecryptData {
+		fixture := UnmarshalTestFixture(test.testFixture)
+		p7, err := Parse(fixture.Input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		content, err := p7.Decrypt(fixture.Certificate, fixture.PrivateKey)
+		if err != nil {
+			t.Errorf("#%d algorithm name: %s, hash function: %s: cannot Decrypt with error: %v", i, test.algorithmName, test.hashFunc, err)
+		}
+		expected := []byte("This is a test")
+		if !bytes.Equal(content, expected) {
+			t.Errorf("#%d algorithm name: %s, hash function: %s: decrypted result does not match.\n\tExpected:%s\n\tActual:%s", i, test.algorithmName, test.hashFunc, expected, content)
+		}
 	}
-	content, err := p7.Decrypt(fixture.Certificate, fixture.PrivateKey)
-	if err != nil {
-		t.Errorf("Cannot Decrypt with error: %v", err)
-	}
-	expected := []byte("This is a test")
-	if !bytes.Equal(content, expected) {
-		t.Errorf("Decrypted result does not match.\n\tExpected:%s\n\tActual:%s", expected, content)
-	}
+}
+
+var testDecryptData = []testDecryptStruct{
+	{name: "rsa-pkcs-#1-v1.5 (1)", algorithmName: "RSA PKCS #1 v1.5", testFixture: EncryptedTestFixture},
+	{name: "rsa-pkcs-#1-v1.5 (2)", algorithmName: "RSA PKCS #1 v1.5", testFixture: RSAPKCS1v15EncryptedTestFixture},
+	{name: "rsa-oaep-sha1", algorithmName: "RSA-OAEP", hashFunc: "SHA-1", testFixture: RSAOAEPSHA1EncryptedTestFixture},
+	{name: "rsa-oaep-sha256", algorithmName: "RSA-OAEP", hashFunc: "SHA-256", testFixture: RSAOAEPSHA256EncryptedTestFixture},
 }
 
 // echo -n "This is a test" > test.txt
@@ -59,3 +72,200 @@ o5FC5Jg2FUfFzZSDmyZ6IONUsdF/i78KDV5nRv1R+hI6/oRlWNCtTNBv/lvBBd6b
 dseUE9QoaQZsn5lpILEvmQJAZ0B+Or1rAYjnbjnUhdVZoy9kC4Zov+4UH3N/BtSy
 KJRWUR0wTWfZBPZ5hAYZjTBEAFULaYCXlQKsODSp0M1aQA==
 -----END PRIVATE KEY-----`
+
+//   - Generate new private key using openssl genrsa -out key.pem 2048
+//   - Create a self-signed certificate for key.pem using
+//     openssl req -x509 -key key.pem -out certificate.pem
+//   - Create a file with the data to be encrypted using
+//     echo -n "This is a test" > test.txt
+//   - Generate PKCS #7 enveloped data encrypted using AES using
+//     openssl smime -encrypt -in test.txt -aes256 -outform pem certificate.pem
+var RSAPKCS1v15EncryptedTestFixture = `
+-----BEGIN PKCS7-----
+MIIBwgYJKoZIhvcNAQcDoIIBszCCAa8CAQAxggFqMIIBZgIBADBOMDYxCzAJBgNV
+BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMRIwEAYDVQQKDAlUZXN0IENlcnQC
+FCoCAvxWlBvVDwodj5frshHwg0GSMA0GCSqGSIb3DQEBAQUABIIBABvjuG8mbhW6
+SQkYvyfs3S8BQxQJwl1I/wLckEB8YClEItw4ZCsDXVodJpAtQ+fiQPRpQLMksD22
+IXVxdRrAV2/Nzl1g8vLa1ae3zh9pQsEOf0pTzVIChB3WgQegOkpu88i6Vp/TNzUp
+fYezUTVRgHC7cJMOciYMLVxgKRdjLVZeyaqKY6zU1OgKy0/JQpfRk6rlTyMltMDY
+2mjywc/lP9GCNfMxpSpj/CpN+2YKYxKOdht3dpO5e13WWzhYmz7oUeLRN4AC9M4N
+Cfa8qYh3ipJauxCT4qeBIIDidHSA9iP8h3Ro3d+7q9Imf1UjJvuDmc8A8UlFdTRE
+r4tg/TnnVeAwPAYJKoZIhvcNAQcBMB0GCWCGSAFlAwQBKgQQ1Az0LE0/4y9NjXZ7
+JSh3X4AQD6BD9BghuxT99dPWWkyRlw==
+-----END PKCS7-----
+-----BEGIN CERTIFICATE-----
+MIIDTTCCAjWgAwIBAgIUKgIC/FaUG9UPCh2Pl+uyEfCDQZIwDQYJKoZIhvcNAQEL
+BQAwNjELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxEjAQBgNVBAoM
+CVRlc3QgQ2VydDAeFw0yMTAyMTAxNjIwMDBaFw0yMTAzMTIxNjIwMDBaMDYxCzAJ
+BgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMRIwEAYDVQQKDAlUZXN0IENl
+cnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDS+Nd7wSgX6j6xLCZd
+SdwAq8BWlbruuFEf6VYvZ5FBzIOeTwFketD1tJie8tq9sEv8V8sFYlZruM4mA12G
+jxSse5rwVTf6TomQChEuvW+l6dB4N7EQ6EtZ1bmBKUk0jhqmrHTgT8YbyBKZ/2t+
+UqkcvmHIPBMUEHwEOqGjj+RsRb69qYZYWTbtUjBbEt2PBk2noVtd7yyqvtPUl/p0
+LAhL9oAsZTgL4LiZaOo9NGV6AkJWYQJuONOXSkx34Sn6V7xLPLhD/FDv8q3X9WuP
+dc00rlLDWpa2zn8dI3MNK+Q8KTi643f3MpfOiE0xuj13Hwp2QkfsgLdoER3OTFEK
+UmedAgMBAAGjUzBRMB0GA1UdDgQWBBRaaQq4a4U1xwlriTHnfBq8X5ctvDAfBgNV
+HSMEGDAWgBRaaQq4a4U1xwlriTHnfBq8X5ctvDAPBgNVHRMBAf8EBTADAQH/MA0G
+CSqGSIb3DQEBCwUAA4IBAQDFURgxrMBCmMVZFR9+jlCAK9T/tH3tX4d2iIVaj1Aj
+dw0wDAO20QPM/ZHlPM+l8yMT8ACY5ZHp6neRcaz9qmNeYAeGVu5twIo30LfRWDoY
+rfL3gIHeUXQCdxwJMh3z14WNdxPBoPXerw9LT1J97Dg81e/b+Za/vdRfqNIKbADj
+yoP7LBNaX/r83/SsGGbtW618sar+27wWRlGeZvFq8hwh+qyj3S7wtY7wx5weR7eZ
+S9K/MB9npTbIjDUidByTIhpk0hS55s1jF6U0wlmV0oUmC4wBIebyo1cL/CMPRv+a
+z/D9/ZvUoaotiATRWSKLCmxapcmGbMxhHHYWYWtzPCt1
+-----END CERTIFICATE-----
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEA0vjXe8EoF+o+sSwmXUncAKvAVpW67rhRH+lWL2eRQcyDnk8B
+ZHrQ9bSYnvLavbBL/FfLBWJWa7jOJgNdho8UrHua8FU3+k6JkAoRLr1vpenQeDex
+EOhLWdW5gSlJNI4apqx04E/GG8gSmf9rflKpHL5hyDwTFBB8BDqho4/kbEW+vamG
+WFk27VIwWxLdjwZNp6FbXe8sqr7T1Jf6dCwIS/aALGU4C+C4mWjqPTRlegJCVmEC
+bjjTl0pMd+Ep+le8Szy4Q/xQ7/Kt1/Vrj3XNNK5Sw1qWts5/HSNzDSvkPCk4uuN3
+9zKXzohNMbo9dx8KdkJH7IC3aBEdzkxRClJnnQIDAQABAoIBAF8IKoCbbIUBRkYm
+ng1tpMVEmHooLjE0I47dW64019Cs4Cjia70oOZJETG9k87V4gXHk1hXRyx3w/CNR
+ZsKjFuvvLcbOjE2bLQoODtlgCbfRz88nPwJfsPmBdXNB9rDOxiCIFImqRZHkGMT3
+siMP9w90jrVUoj9qgYKiKodz3LAMFLnc6QkuAPRdEEI14bxRCcc3w2nKcCbj8Yye
+qKDbWVqp36kWBYcWgD2vzRcBOjJ3mRvTwflEg8HXbU88ANlGf7QQ1YhB9ueAE9Eg
+E18BMoa8cjon+xH2OvH+PlOZkbCLojoFtlUSh99eApp51+DCTKwQfqeg5ufdwm5G
+vyci9X0CgYEA+tFy8dqGOlmHDRUg3lW68dA1zkm15WAZoj7NvCGvTQyfoeH3Syoo
+CNKJqJkGHVWksCbTnORGVLDsz+l5a2BJY3L0xiDxpciIomZO18/IGJ4K5X4tm10i
+330jUMO/22BXgNzBLU8gIyQLIu45NgOugtfwFKrCvYER4m0/peXWtB8CgYEA11Sm
+mC9V3mwceUuHWgqxsZpxrTQEDTAOhrGiIl5ZtoD7moMpu9MOo3qGd8W4dNbQwONq
+RxDigTQWv9oxqqDTYQjoZRSo1zYYgn9K17V5v4P1pzFMVBJnK1ElciWObt9l2g4O
+B/+SWQncwShHhfwJPrYmVQGgb3fETfZiiGvyTMMCgYEAxf4MtKqCBxGhMEybc6dN
+OZHYx40cT4M6+P6GvZoBndr3MH0GD4mprL01+adCUmnG5V7g8RqqAjTf24g8Vuzd
+Qen/G1/qIapZYYlNd8MH+5bWly6xpdExtCY+eITtsKkuqgSZYcDyZ4sOV3aiJudl
+HNiFJmtd6uY2Tf1bnwP+JpUCgYA4aup3Rze1Xhgbw6lD8zdZdEDCg7VoCyZTLilv
+3c6dna/ObP07Q/I67PhcW0aX/kyVrUAEPK1L8uze+Xk33oljjCTvjvkp4feMAXQH
+jnnGrvlnA+iewm+bjthDzwlBjXCvMC2G9PRQNeBMD5Sly0JU1v62GQYDDps1Xg+0
+9Kt4ZwKBgF8995suzG285txhAnlbKJpXB67f20s0DpBb4QdB+1PuizuyWWxPYAcu
+J1h1Q5Z6frEwd4ye/bcpReEScPXOKEB+1b3TWGCWNC2jhfChtZSH1Y3Z3mL0SfwT
+n9txBjxLOx1G83OQYY3J6Bnwkn5/whXGdMlfOR963adQNweQuatB
+-----END RSA PRIVATE KEY-----`
+
+//   - Generate new private key using openssl genrsa -out key.pem 2048
+//   - Create a self-signed certificate for key.pem using
+//     openssl req -x509 -key key.pem -out certificate.pem
+//   - Create a file with the data to be encrypted using
+//     echo -n "This is a test" > test.txt
+//   - Generate PKCS #7 enveloped data encrypted using AES using
+//     openssl cms -encrypt -in test.txt -outform pem -recip certificate.pem -aes256 -keyopt rsa_padding_mode:oaep
+//   - Change the CMS header to the PKCS7 header.
+var RSAOAEPSHA1EncryptedTestFixture = `
+-----BEGIN PKCS7-----
+MIIBwgYJKoZIhvcNAQcDoIIBszCCAa8CAQAxggFqMIIBZgIBADBOMDYxCzAJBgNV
+BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMRIwEAYDVQQKDAlUZXN0IENlcnQC
+FCoCAvxWlBvVDwodj5frshHwg0GSMA0GCSqGSIb3DQEBBzAABIIBAJk/va3ss8Rc
+1hs7V7uo4XwrV+VVJMQtSnAwp2YihMtSPj3hiS6ZbhoadrK5tGersZZLiz25Wr9u
+qMc5D6EpCeo6dr4Fy4JJvBb6dox1X5jzA4G2m1gKv+J+KthWLBEuBKKYYeVIayr4
+qiqyPW1re0yEREMapXfBHdzcYAHCa+sSomkYpMAHCqHd04uk8lznIE8mt/p3dJQx
+QqFtYQ1YHeXFTEoVFnumVjyWwFX2fMgjSkdA34v/xDQc2HP81QMC45f5HOVbPk/Z
+EmOBSvoUL9VQWKMwxS2RGDQKAZMbYOn948TI0DyairG5BQzHFC3OWUlp/DpVJoIA
+c40TpDjW1bAwPAYJKoZIhvcNAQcBMB0GCWCGSAFlAwQBKgQQSHiMHMNoG+HSC12p
+ym5+dYAQ4qvztP5U0tRnA7ezUef7Fg==
+-----END PKCS7-----
+-----BEGIN CERTIFICATE-----
+MIIDTTCCAjWgAwIBAgIUKgIC/FaUG9UPCh2Pl+uyEfCDQZIwDQYJKoZIhvcNAQEL
+BQAwNjELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxEjAQBgNVBAoM
+CVRlc3QgQ2VydDAeFw0yMTAyMTAxNjIwMDBaFw0yMTAzMTIxNjIwMDBaMDYxCzAJ
+BgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMRIwEAYDVQQKDAlUZXN0IENl
+cnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDS+Nd7wSgX6j6xLCZd
+SdwAq8BWlbruuFEf6VYvZ5FBzIOeTwFketD1tJie8tq9sEv8V8sFYlZruM4mA12G
+jxSse5rwVTf6TomQChEuvW+l6dB4N7EQ6EtZ1bmBKUk0jhqmrHTgT8YbyBKZ/2t+
+UqkcvmHIPBMUEHwEOqGjj+RsRb69qYZYWTbtUjBbEt2PBk2noVtd7yyqvtPUl/p0
+LAhL9oAsZTgL4LiZaOo9NGV6AkJWYQJuONOXSkx34Sn6V7xLPLhD/FDv8q3X9WuP
+dc00rlLDWpa2zn8dI3MNK+Q8KTi643f3MpfOiE0xuj13Hwp2QkfsgLdoER3OTFEK
+UmedAgMBAAGjUzBRMB0GA1UdDgQWBBRaaQq4a4U1xwlriTHnfBq8X5ctvDAfBgNV
+HSMEGDAWgBRaaQq4a4U1xwlriTHnfBq8X5ctvDAPBgNVHRMBAf8EBTADAQH/MA0G
+CSqGSIb3DQEBCwUAA4IBAQDFURgxrMBCmMVZFR9+jlCAK9T/tH3tX4d2iIVaj1Aj
+dw0wDAO20QPM/ZHlPM+l8yMT8ACY5ZHp6neRcaz9qmNeYAeGVu5twIo30LfRWDoY
+rfL3gIHeUXQCdxwJMh3z14WNdxPBoPXerw9LT1J97Dg81e/b+Za/vdRfqNIKbADj
+yoP7LBNaX/r83/SsGGbtW618sar+27wWRlGeZvFq8hwh+qyj3S7wtY7wx5weR7eZ
+S9K/MB9npTbIjDUidByTIhpk0hS55s1jF6U0wlmV0oUmC4wBIebyo1cL/CMPRv+a
+z/D9/ZvUoaotiATRWSKLCmxapcmGbMxhHHYWYWtzPCt1
+-----END CERTIFICATE-----
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEA0vjXe8EoF+o+sSwmXUncAKvAVpW67rhRH+lWL2eRQcyDnk8B
+ZHrQ9bSYnvLavbBL/FfLBWJWa7jOJgNdho8UrHua8FU3+k6JkAoRLr1vpenQeDex
+EOhLWdW5gSlJNI4apqx04E/GG8gSmf9rflKpHL5hyDwTFBB8BDqho4/kbEW+vamG
+WFk27VIwWxLdjwZNp6FbXe8sqr7T1Jf6dCwIS/aALGU4C+C4mWjqPTRlegJCVmEC
+bjjTl0pMd+Ep+le8Szy4Q/xQ7/Kt1/Vrj3XNNK5Sw1qWts5/HSNzDSvkPCk4uuN3
+9zKXzohNMbo9dx8KdkJH7IC3aBEdzkxRClJnnQIDAQABAoIBAF8IKoCbbIUBRkYm
+ng1tpMVEmHooLjE0I47dW64019Cs4Cjia70oOZJETG9k87V4gXHk1hXRyx3w/CNR
+ZsKjFuvvLcbOjE2bLQoODtlgCbfRz88nPwJfsPmBdXNB9rDOxiCIFImqRZHkGMT3
+siMP9w90jrVUoj9qgYKiKodz3LAMFLnc6QkuAPRdEEI14bxRCcc3w2nKcCbj8Yye
+qKDbWVqp36kWBYcWgD2vzRcBOjJ3mRvTwflEg8HXbU88ANlGf7QQ1YhB9ueAE9Eg
+E18BMoa8cjon+xH2OvH+PlOZkbCLojoFtlUSh99eApp51+DCTKwQfqeg5ufdwm5G
+vyci9X0CgYEA+tFy8dqGOlmHDRUg3lW68dA1zkm15WAZoj7NvCGvTQyfoeH3Syoo
+CNKJqJkGHVWksCbTnORGVLDsz+l5a2BJY3L0xiDxpciIomZO18/IGJ4K5X4tm10i
+330jUMO/22BXgNzBLU8gIyQLIu45NgOugtfwFKrCvYER4m0/peXWtB8CgYEA11Sm
+mC9V3mwceUuHWgqxsZpxrTQEDTAOhrGiIl5ZtoD7moMpu9MOo3qGd8W4dNbQwONq
+RxDigTQWv9oxqqDTYQjoZRSo1zYYgn9K17V5v4P1pzFMVBJnK1ElciWObt9l2g4O
+B/+SWQncwShHhfwJPrYmVQGgb3fETfZiiGvyTMMCgYEAxf4MtKqCBxGhMEybc6dN
+OZHYx40cT4M6+P6GvZoBndr3MH0GD4mprL01+adCUmnG5V7g8RqqAjTf24g8Vuzd
+Qen/G1/qIapZYYlNd8MH+5bWly6xpdExtCY+eITtsKkuqgSZYcDyZ4sOV3aiJudl
+HNiFJmtd6uY2Tf1bnwP+JpUCgYA4aup3Rze1Xhgbw6lD8zdZdEDCg7VoCyZTLilv
+3c6dna/ObP07Q/I67PhcW0aX/kyVrUAEPK1L8uze+Xk33oljjCTvjvkp4feMAXQH
+jnnGrvlnA+iewm+bjthDzwlBjXCvMC2G9PRQNeBMD5Sly0JU1v62GQYDDps1Xg+0
+9Kt4ZwKBgF8995suzG285txhAnlbKJpXB67f20s0DpBb4QdB+1PuizuyWWxPYAcu
+J1h1Q5Z6frEwd4ye/bcpReEScPXOKEB+1b3TWGCWNC2jhfChtZSH1Y3Z3mL0SfwT
+n9txBjxLOx1G83OQYY3J6Bnwkn5/whXGdMlfOR963adQNweQuatB
+-----END RSA PRIVATE KEY-----`
+
+var RSAOAEPSHA256EncryptedTestFixture = `
+-----BEGIN PKCS7-----
+MIIBtgYJKoZIhvcNAQcDoIIBpzCCAaMCAQAxggFeMIIBWgIBADAxMCkxEDAOBgNV
+BAoTB0FjbWUgQ28xFTATBgNVBAMTDEVkZGFyZCBTdGFyawIEItzA4TAeBgkqhkiG
+9w0BAQcwEaAPMA0GCWCGSAFlAwQCAQUABIIBAFI8WCPbFK8sEkWFZKtcla39k0DA
+HL+iS16Is+6lKFpanTq1L1DUYfdNJe1raRy/0aHV7sOnugIXyMo5daKOqyJlcgr/
+UR9iTu1mUADX+F3W/IeIIBrsFI73PsW30yk8uazjCGOh79TAmwjLSUMy/IV1LNKf
+mZEzfyaB8EEx1br7kW4tQ+DjW2VqMzKdVxNgzhrTR+VLiBkuGVGsdSEfFkJAYfhp
+4kcqzsE+VZ93v0wnB7g0r9GckBox0OWeYHsldkOQPA6OrGL/54MxxcOdh0mh0i2l
+azux8yBteKsUJG9y+J78DFBwZtOsy4u2Rat895K31GDew3sgHofeeFNHA8kwPAYJ
+KoZIhvcNAQcBMB0GCWCGSAFlAwQBKgQQ4bmABhs/EKBtcfYEwHk2wIAQuA3tdOYV
+oKGnb5jFQi17VA==
+-----END PKCS7-----
+-----BEGIN CERTIFICATE-----
+MIIDETCCAfmgAwIBAgIEItzA4TANBgkqhkiG9w0BAQsFADApMRAwDgYDVQQKEwdB
+Y21lIENvMRUwEwYDVQQDEwxFZGRhcmQgU3RhcmswHhcNMjEwMjIzMTIxODQ2WhcN
+MjIwMjIzMTIxODQ3WjAlMRAwDgYDVQQKEwdBY21lIENvMREwDwYDVQQDEwhKb24g
+U25vdzCCAR8wDQYJKoZIhvcNAQEBBQADggEMADCCAQcCggEAcWPIQrIZColwlCsn
+ZK7ULUEkZHtvMOCaLaHA4laqLuJOeQxAyWpL1m11w3GpFeBwPEdrThoG8b04xaPB
+CuO9MPTvYqWqT1Eq0UWgbEjpZGmiLOjmIeBS8GaajDQVVRLYLlVEfwt+GNqUvZEa
+x7OqvnBoQ2aJZFk+5xsuXkhLzwx4NBAatdYbuh5j5iN69ASJzjaiYNq3Ct1PvsJN
+ZZ2w98rAmbCjqkVJrN5/yFink6l15s9lyidrdDUl8Ig5gPatBpvsNG14d5c4bVD+
+DJc0vpZ8fYSuW480mwlAeUV8DAxv7jTEKguDJgOAT3HknzMgCBY3USxsvyu4G29r
+4jmEbQIBA6NIMEYwDgYDVR0PAQH/BAQDAgWgMBMGA1UdJQQMMAoGCCsGAQUFBwME
+MB8GA1UdIwQYMBaAFOy+qIFIokwb/0GSIt4DOBOXMd5vMA0GCSqGSIb3DQEBCwUA
+A4IBAQA8F85MhBw5QxwrwRluL4waSXpxdRNpkN2K59eEqTUc+5lFLhinvX9WwkvR
+ToBiRpvX50GtCWZ/r5Lx2UxTyh3vKsgjhkXcvm6pvVVfqyz5pNQv3v2Q838xM98+
+15srGU9uU71McPZ5MmkmfHfgBaz5CCfUcsroJJ19pebaSARkRnb0bR36voXUbtwM
+F89PLjXUYLxSaWcOpRQ1ju0Kq7K3MDqauPzzl3HtrpGkCsoHMfb5o/HYNj+Pmxfl
+l3QH5xhOzVdioaGwE4SkY5Z5szZ8n+qi/Zd59PBCOpLoXvcB9WRTMmYkxmDOVcwI
+pQfViIYaatHkjbS/2C/Cx0hfb/6S
+-----END CERTIFICATE-----
+-----BEGIN RSA PRIVATE KEY-----
+MIIEnwIBAAKCAQBxY8hCshkKiXCUKydkrtQtQSRke28w4JotocDiVqou4k55DEDJ
+akvWbXXDcakV4HA8R2tOGgbxvTjFo8EK470w9O9ipapPUSrRRaBsSOlkaaIs6OYh
+4FLwZpqMNBVVEtguVUR/C34Y2pS9kRrHs6q+cGhDZolkWT7nGy5eSEvPDHg0EBq1
+1hu6HmPmI3r0BInONqJg2rcK3U++wk1lnbD3ysCZsKOqRUms3n/IWKeTqXXmz2XK
+J2t0NSXwiDmA9q0Gm+w0bXh3lzhtUP4MlzS+lnx9hK5bjzSbCUB5RXwMDG/uNMQq
+C4MmA4BPceSfMyAIFjdRLGy/K7gbb2viOYRtAgEDAoIBAEuX2tchZgcGSw1yGkMf
+OB4rbZhSSiCVvB5r1ew5xsnsNFCy1ducMo7zo9ehG2Pq9X2E8jQRWfZ+JdkX1gdC
+fiCjSkHDxt+LceDZFZ2F8O2bwXNF7sFAN0rvEbLNY44MkB7jgv9c/rs8YykLZy/N
+HH71mteZsO2Q1JoSHumFh99cwWHFhLxYh64qFeeH6Gqx6AM2YVBWHgs7OuKOvc8y
+zUbf8xftPht1kMwwDR1XySiEYtBtn74JflK3DcT8oxOuCZBuX6sMJHKbVP41zDj+
+FJZBmpAvNfCEYJUr1Hg+DpMLqLUg+D6v5vpliburbk9LxcKFZyyZ9QVe7GoqMLBu
+eGsCgYEAummUj4MMKWJC2mv5rj/dt2pj2/B2HtP2RLypai4et1/Ru9nNk8cjMLzC
+qXz6/RLuJ7/eD7asFS3y7EqxKxEmW0G8tTHjnzR/3wnpVipuWnwCDGU032HJVd13
+LMe51GH97qLzuDZjMCz+VlbCNdSslMgWWK0XmRnN7Yqxvh6ao2kCgYEAm7fTRBhF
+JtKcaJ7d8BQb9l8BNHfjayYOMq5CxoCyxa2pGBv/Mrnxv73Twp9Z/MP0ue5M5nZt
+GMovpP5cGdJLQ2w5p4H3opcuWeYW9Yyru2EyCEAI/hD/Td3QVP0ukc19BDuPl5Wg
+eIFs218uiVOU4pw3w+Et5B1PZ/F+ZLr5LGUCgYB8RmMKV11w7CyRnVEe1T56Ru09
+Svlp4qQt0xucHr8k6ovSkTO32hd10yxw/fyot0lv1T61JHK4yUydhyDHYMQ81n3O
+IUJqIv/qBpuOxvQ8UqwIQ3iU69uOk6TIhSaNlqlJwffQJEIgHf7kOdbOjchjMA7l
+yLpmETPzscvUFGcXmwKBgGfP4i1lg283EvBp6Uq4EqQ/ViL6l5zECXce1y8Ady5z
+xhASqiHRS9UpN9cU5qiCoyae3e75nhCGym3+6BE23Nede8UBT8G6HuaZZKOzHSeW
+IVrVW1QLVN6T4DioybaI/gLSX7pjwFBWSJI/dFuNDexoJS1AyUK+NO/2VEMnUMhD
+AoGAOsdn3Prnh/mjC95vraHCLap0bRBSexMdx77ImHgtFUUcSaT8DJHs+NZw1RdM
+SZA0J+zVQ8q7B11jIgz5hMz+chedwoRjTL7a8VRTKHFmmBH0zlEuV7L79w6HkRCQ
+VRg10GUN6heGLv0aOHbPdobcuVDH4sgOqpT1QnOuce34sQs=
+-----END RSA PRIVATE KEY-----`

--- a/pkcs7.go
+++ b/pkcs7.go
@@ -64,6 +64,7 @@ var (
 
 	// Signature Algorithms
 	OIDEncryptionAlgorithmRSA       = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 1}
+	OIDEncryptionAlgorithmRSAMD5    = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 4}
 	OIDEncryptionAlgorithmRSASHA1   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 5}
 	OIDEncryptionAlgorithmRSAESOAEP = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 7}
 	OIDEncryptionAlgorithmRSASHA256 = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 11}

--- a/pkcs7.go
+++ b/pkcs7.go
@@ -53,6 +53,7 @@ var (
 	OIDDigestAlgorithmSHA256 = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 1}
 	OIDDigestAlgorithmSHA384 = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 2}
 	OIDDigestAlgorithmSHA512 = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 3}
+	OIDDigestAlgorithmSHA224 = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 4}
 
 	OIDDigestAlgorithmDSA     = asn1.ObjectIdentifier{1, 2, 840, 10040, 4, 1}
 	OIDDigestAlgorithmDSASHA1 = asn1.ObjectIdentifier{1, 2, 840, 10040, 4, 3}
@@ -70,6 +71,7 @@ var (
 	OIDEncryptionAlgorithmRSASHA256 = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 11}
 	OIDEncryptionAlgorithmRSASHA384 = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 12}
 	OIDEncryptionAlgorithmRSASHA512 = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 13}
+	OIDEncryptionAlgorithmRSASHA224 = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 14}
 
 	OIDEncryptionAlgorithmECDSAP256 = asn1.ObjectIdentifier{1, 2, 840, 10045, 3, 1, 7}
 	OIDEncryptionAlgorithmECDSAP384 = asn1.ObjectIdentifier{1, 3, 132, 0, 34}

--- a/pkcs7.go
+++ b/pkcs7.go
@@ -65,6 +65,7 @@ var (
 	// Signature Algorithms
 	OIDEncryptionAlgorithmRSA       = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 1}
 	OIDEncryptionAlgorithmRSASHA1   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 5}
+	OIDEncryptionAlgorithmRSAESOAEP = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 7}
 	OIDEncryptionAlgorithmRSASHA256 = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 11}
 	OIDEncryptionAlgorithmRSASHA384 = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 12}
 	OIDEncryptionAlgorithmRSASHA512 = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 13}

--- a/pkcs7_test.go
+++ b/pkcs7_test.go
@@ -317,7 +317,7 @@ func UnmarshalTestFixture(testPEMBlock string) TestFixture {
 			result.Input = derBlock.Bytes
 		case "CERTIFICATE":
 			result.Certificate, _ = x509.ParseCertificate(derBlock.Bytes)
-		case "PRIVATE KEY":
+		case "PRIVATE KEY", "RSA PRIVATE KEY":
 			result.PrivateKey, _ = x509.ParsePKCS1PrivateKey(derBlock.Bytes)
 		}
 	}


### PR DESCRIPTION
Changes from https://github.com/mozilla-services/pkcs7/pull/48 are included with this PR. Slightly adapted to fit with how we work with `crypto.Decrypter`.

Changes from https://github.com/mozilla-services/pkcs7/pull/44 for decryption are included with this PR.