### PR TITLE
`EncryptedContent` needs to be implicitly tagged and not explicit

### DIFF
--- a/encrypt.go
+++ b/encrypt.go
@@ -443,8 +443,7 @@ func EncryptUsingPSK(content []byte, key []byte) ([]byte, error) {
 }
 
 func marshalEncryptedContent(content []byte) asn1.RawValue {
-	asn1Content, _ := asn1.Marshal(content)
-	return asn1.RawValue{Tag: 0, Class: 2, Bytes: asn1Content, IsCompound: true}
+	return asn1.RawValue{Bytes: content, Class: 2, IsCompound: false}
 }
 
 func encryptKey(key []byte, recipient *x509.Certificate, algorithm asn1.ObjectIdentifier, hash crypto.Hash) ([]byte, error) {


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

bug: `EncryptedContent` needs to be implicit but tagged explicit

#### Pain or issue this feature alleviates:

Against stricter parsers the emitted `EncryptedContent` fails to get parsed since it's considered explicit and not implicit 

#### In what environments or workflows is this feature supported?

I am currently using: go version go1.20.7 darwin/amd64

#### Supporting links/other PRs/issues:

Issue filed: https://github.com/mozilla-services/pkcs7/issues/84
PR opened here as well: https://github.com/mozilla-services/pkcs7/pull/83 

Related fix: https://github.com/fullsailor/pkcs7/commit/cddbb99c85db9a927ad8f22bedf5891e1c7fe934 But this is not sufficient to make the emitted `EncryptedContent` implicit.

💔Thank you!
