### PR TITLE
fix(ber): prevent race due to unnecessary var

### DIFF
--- a/ber.go
+++ b/ber.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 )
 
-var encodeIndent = 0
-
 type asn1Object interface {
 	EncodeTo(writer *bytes.Buffer) error
 }
@@ -17,8 +15,6 @@ type asn1Structured struct {
 }
 
 func (s asn1Structured) EncodeTo(out *bytes.Buffer) error {
-	//fmt.Printf("%s--> tag: % X\n", strings.Repeat("| ", encodeIndent), s.tagBytes)
-	encodeIndent++
 	inner := new(bytes.Buffer)
 	for _, obj := range s.content {
 		err := obj.EncodeTo(inner)
@@ -26,7 +22,6 @@ func (s asn1Structured) EncodeTo(out *bytes.Buffer) error {
 			return err
 		}
 	}
-	encodeIndent--
 	out.Write(s.tagBytes)
 	encodeLength(out, inner.Len())
 	out.Write(inner.Bytes())
@@ -47,8 +42,8 @@ func (p asn1Primitive) EncodeTo(out *bytes.Buffer) error {
 	if err = encodeLength(out, p.length); err != nil {
 		return err
 	}
-	//fmt.Printf("%s--> tag: % X length: %d\n", strings.Repeat("| ", encodeIndent), p.tagBytes, p.length)
-	//fmt.Printf("%s--> content length: %d\n", strings.Repeat("| ", encodeIndent), len(p.content))
+	// fmt.Printf("%s--> tag: % X length: %d\n", strings.Repeat("| ", encodeIndent), p.tagBytes, p.length)
+	// fmt.Printf("%s--> content length: %d\n", strings.Repeat("| ", encodeIndent), len(p.content))
 	out.Write(p.content)
 
 	return nil
@@ -58,7 +53,7 @@ func ber2der(ber []byte) ([]byte, error) {
 	if len(ber) == 0 {
 		return nil, errors.New("ber2der: input ber is empty")
 	}
-	//fmt.Printf("--> ber2der: Transcoding %d bytes\n", len(ber))
+	// fmt.Printf("--> ber2der: Transcoding %d bytes\n", len(ber))
 	out := new(bytes.Buffer)
 
 	obj, _, err := readObject(ber, 0)
@@ -69,7 +64,7 @@ func ber2der(ber []byte) ([]byte, error) {
 
 	// if offset < len(ber) {
 	//	return nil, fmt.Errorf("ber2der: Content longer than expected. Got %d, expected %d", offset, len(ber))
-	//}
+	// }
 
 	return out.Bytes(), nil
 }
@@ -154,7 +149,7 @@ func readObject(ber []byte, offset int) (asn1Object, int, error) {
 			}
 		}
 		// jvehent 20170227: this doesn't appear to be used anywhere...
-		//tag = tag*128 + ber[offset] - 0x80
+		// tag = tag*128 + ber[offset] - 0x80
 		offset++
 		if offset > berLen {
 			return nil, 0, errors.New("ber2der: cannot move offset forward, end of ber data reached")
@@ -204,7 +199,7 @@ func readObject(ber []byte, offset int) (asn1Object, int, error) {
 	if length < 0 {
 		return nil, 0, errors.New("ber2der: invalid negative value found in BER tag length")
 	}
-	//fmt.Printf("--> length        : %d\n", length)
+	// fmt.Printf("--> length        : %d\n", length)
 	contentEnd := offset + length
 	if contentEnd > len(ber) {
 		return nil, 0, errors.New("ber2der: BER tag length is more than available data")
@@ -259,7 +254,7 @@ func readObject(ber []byte, offset int) (asn1Object, int, error) {
 }
 
 func isIndefiniteTermination(ber []byte, offset int) (bool, error) {
-	if len(ber) - offset < 2 {
+	if len(ber)-offset < 2 {
 		return false, errors.New("ber2der: Invalid BER format")
 	}
 
@@ -267,5 +262,5 @@ func isIndefiniteTermination(ber []byte, offset int) (bool, error) {
 }
 
 func debugprint(format string, a ...interface{}) {
-	//fmt.Printf(format, a)
+	// fmt.Printf(format, a)
 }


### PR DESCRIPTION
address #23 

#### Name of feature:
Fix race conditions in `ber` file

#### Pain or issue this feature alleviates:
Prevent race condition due to async access to ber's debugging global variable 

#### Why is this important to the project (if not answered above):
Projects that use this package and run `go test ./... -race` will probably end up in situation like below:

```
WARNING: DATA RACE
Read at 0x0000021c46a0 by goroutine 33:
  github.com/smallstep/pkcs7.asn1Structured.EncodeTo()
      /.../vendor/github.com/smallstep/pkcs7/ber.go:21 +0x56
  github.com/smallstep/pkcs7.(*asn1Structured).EncodeTo()
      <autogenerated>:1 +0xa5
  github.com/smallstep/pkcs7.ber2der()
      /.../vendor/github.com/smallstep/pkcs7/ber.go:68 +0xdb
  github.com/smallstep/pkcs7.Parse()
      /.../vendor/github.com/smallstep/pkcs7/pkcs7.go:171 +0x12f
```
