### PR TITLE
add SigningTimeNotValidError error

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -54,15 +54,15 @@ func (p7 *PKCS7) VerifyWithChainAtTime(truststore *x509.CertPool, currentTime ti
 	return nil
 }
 
-// SigningTimeNotValidErr is returned when signing time attribute falls
+// SigningTimeNotValidError is returned when signing time attribute falls
 // outside of the signer certificate validity.
-type SigningTimeNotValidErr struct {
+type SigningTimeNotValidError struct {
 	SigningTime time.Time
 	NotBefore   time.Time // NotBefore of signer
 	NotAfter    time.Time // NotAfter of signer
 }
 
-func (e *SigningTimeNotValidErr) Error() string {
+func (e *SigningTimeNotValidError) Error() string {
 	return fmt.Sprintf("pkcs7: signing time %q is outside of certificate validity %q to %q",
 		e.SigningTime.Format(time.RFC3339),
 		e.NotBefore.Format(time.RFC3339),
@@ -106,7 +106,7 @@ func verifySignatureAtTime(p7 *PKCS7, signer signerInfo, truststore *x509.CertPo
 		if err == nil {
 			// signing time found, performing validity check
 			if signingTime.After(ee.NotAfter) || signingTime.Before(ee.NotBefore) {
-				return &SigningTimeNotValidErr{
+				return &SigningTimeNotValidError{
 					SigningTime: signingTime,
 					NotBefore:   ee.NotBefore,
 					NotAfter:    ee.NotAfter,
@@ -162,7 +162,7 @@ func verifySignature(p7 *PKCS7, signer signerInfo, truststore *x509.CertPool) (e
 		if err == nil {
 			// signing time found, performing validity check
 			if signingTime.After(ee.NotAfter) || signingTime.Before(ee.NotBefore) {
-				return &SigningTimeNotValidErr{
+				return &SigningTimeNotValidError{
 					SigningTime: signingTime,
 					NotBefore:   ee.NotBefore,
 					NotAfter:    ee.NotAfter,

--- a/verify.go
+++ b/verify.go
@@ -54,6 +54,21 @@ func (p7 *PKCS7) VerifyWithChainAtTime(truststore *x509.CertPool, currentTime ti
 	return nil
 }
 
+// SigningTimeNotValidErr is returned when signing time attribute falls
+// outside of the signer certificate validity.
+type SigningTimeNotValidErr struct {
+	SigningTime time.Time
+	NotBefore   time.Time // NotBefore of signer
+	NotAfter    time.Time // NotAfter of signer
+}
+
+func (e *SigningTimeNotValidErr) Error() string {
+	return fmt.Sprintf("pkcs7: signing time %q is outside of certificate validity %q to %q",
+		e.SigningTime.Format(time.RFC3339),
+		e.NotBefore.Format(time.RFC3339),
+		e.NotAfter.Format(time.RFC3339))
+}
+
 func verifySignatureAtTime(p7 *PKCS7, signer signerInfo, truststore *x509.CertPool, currentTime time.Time) (err error) {
 	signedData := p7.Content
 	ee := getCertFromCertsByIssuerAndSerial(p7.Certificates, signer.IssuerAndSerialNumber)
@@ -91,10 +106,11 @@ func verifySignatureAtTime(p7 *PKCS7, signer signerInfo, truststore *x509.CertPo
 		if err == nil {
 			// signing time found, performing validity check
 			if signingTime.After(ee.NotAfter) || signingTime.Before(ee.NotBefore) {
-				return fmt.Errorf("pkcs7: signing time %q is outside of certificate validity %q to %q",
-					signingTime.Format(time.RFC3339),
-					ee.NotBefore.Format(time.RFC3339),
-					ee.NotAfter.Format(time.RFC3339))
+				return &SigningTimeNotValidErr{
+					SigningTime: signingTime,
+					NotBefore:   ee.NotBefore,
+					NotAfter:    ee.NotAfter,
+				}
 			}
 		}
 	}
@@ -146,10 +162,11 @@ func verifySignature(p7 *PKCS7, signer signerInfo, truststore *x509.CertPool) (e
 		if err == nil {
 			// signing time found, performing validity check
 			if signingTime.After(ee.NotAfter) || signingTime.Before(ee.NotBefore) {
-				return fmt.Errorf("pkcs7: signing time %q is outside of certificate validity %q to %q",
-					signingTime.Format(time.RFC3339),
-					ee.NotBefore.Format(time.RFC3339),
-					ee.NotAfter.Format(time.RFC3339))
+				return &SigningTimeNotValidErr{
+					SigningTime: signingTime,
+					NotBefore:   ee.NotBefore,
+					NotAfter:    ee.NotAfter,
+				}
 			}
 		}
 	}


### PR DESCRIPTION
#### Name of feature:

Add a specific typed error for an invalid signing time attribute invalid error.

#### Pain or issue this feature alleviates:

See discussion in #21.

#### Why is this important to the project (if not answered above):

Allows the capability specific handling of a signing time attribute by the caller of `.Verify()` via e.g. `errors.Is()`. This would expose the specific signing time time.Time object along with the NotAfter and NotBefore of the signer.

#### Is there documentation on how to use this feature? If so, where?

As an exported symbol the Go documentation should auto-generate once a release is cut.

#### In what environments or workflows is this feature supported?

Anybody using the P7 library.

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

I suppose this error is never called if there's no signing time attribute (or it is valid).

#### Supporting links/other PRs/issues:

Again, see #21.

💔Thank you!
