### PR TITLE
Add support for custom hash calculation function, allowing content streaming

### DIFF
--- a/pkcs7.go
+++ b/pkcs7.go
@@ -12,6 +12,7 @@ import (
 	"encoding/asn1"
 	"errors"
 	"fmt"
+	"hash"
 	"sort"
 	"sync"
 
@@ -26,6 +27,7 @@ type PKCS7 struct {
 	Certificates []*x509.Certificate
 	CRLs         []pkix.CertificateList
 	Signers      []signerInfo
+	HashCalc     func(hash.Hash, []byte) []byte
 	raw          interface{}
 }
 

--- a/verify.go
+++ b/verify.go
@@ -90,8 +90,13 @@ func verifySignatureAtTime(p7 *PKCS7, signer signerInfo, truststore *x509.CertPo
 			return err
 		}
 		h := hash.New()
-		h.Write(p7.Content)
-		computed := h.Sum(nil)
+		var computed []byte
+		if p7.HashCalc != nil {
+			computed = p7.HashCalc(h, p7.Content)
+		} else {
+			h.Write(p7.Content)
+			computed = h.Sum(nil)
+		}
 		if subtle.ConstantTimeCompare(digest, computed) != 1 {
 			return &MessageDigestMismatchError{
 				ExpectedDigest: digest,
@@ -146,8 +151,13 @@ func verifySignature(p7 *PKCS7, signer signerInfo, truststore *x509.CertPool) (e
 			return err
 		}
 		h := hash.New()
-		h.Write(p7.Content)
-		computed := h.Sum(nil)
+		var computed []byte
+		if p7.HashCalc != nil {
+			computed = p7.HashCalc(h, p7.Content)
+		} else {
+			h.Write(p7.Content)
+			computed = h.Sum(nil)
+		}
 		if subtle.ConstantTimeCompare(digest, computed) != 1 {
 			return &MessageDigestMismatchError{
 				ExpectedDigest: digest,


### PR DESCRIPTION
#### Name of feature:
Hash calculation function support

#### Pain or issue this feature alleviates:
This change provides the ability to add a custom function for calculating the content hash.

This is useful for calculating the hash of the content as it is being streamed, instead of requiring the entire content to be loaded into memory, and is necessary for calculating hashes on large files without excessive memory usage.

#### Why is this important to the project (if not answered above):

#### Is there documentation on how to use this feature? If so, where?

Example for usage can be seen in test file, where instead of setting p7.Content, we use the p7.HashCalc (setting Content is optional when using HashCalc):
```go
	reader := bytes.NewReader([]byte(longBuffer))
	p7.HashCalc = func(h hash.Hash, b []byte) []byte {
		bufferSize := 128
		buffer := make([]byte, bufferSize)
		for {
			count, err := reader.Read(buffer)
			if err != nil {
				break
			}
			h.Write(buffer[:count])
		}
		return h.Sum(nil)
	}
```
#### In what environments or workflows is this feature supported?

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:

💔Thank you!
