### PR TITLE
Update the Default Digest for Envelope Signing to SHA2-256 

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -1,0 +1,45 @@
+//go:build !requirefips
+// +build !requirefips
+
+package pkcs7
+
+import "crypto"
+
+const (
+	// EncryptionAlgorithmDESCBC is the DES CBC encryption algorithm
+	EncryptionAlgorithmDESCBC = iota
+
+	// EncryptionAlgorithmAES128CBC is the AES 128 bits with CBC encryption algorithm
+	// Avoid this algorithm unless required for interoperability; use AES GCM instead.
+	EncryptionAlgorithmAES128CBC
+
+	// EncryptionAlgorithmAES256CBC is the AES 256 bits with CBC encryption algorithm
+	// Avoid this algorithm unless required for interoperability; use AES GCM instead.
+	EncryptionAlgorithmAES256CBC
+
+	// EncryptionAlgorithmAES128GCM is the AES 128 bits with GCM encryption algorithm
+	EncryptionAlgorithmAES128GCM
+
+	// EncryptionAlgorithmAES256GCM is the AES 256 bits with GCM encryption algorithm
+	EncryptionAlgorithmAES256GCM
+)
+
+// ContentEncryptionAlgorithm determines the algorithm used to encrypt the
+// plaintext message. Change the value of this variable to change which
+// algorithm is used in the Encrypt() function.
+var ContentEncryptionAlgorithm = EncryptionAlgorithmAES256CBC
+
+// KeyEncryptionHash determines the crypto.Hash algorithm to use
+// when encrypting a content key. Change the value of this variable
+// to change which algorithm is used in the Encrypt() function.
+var KeyEncryptionHash = crypto.SHA256
+
+// KeyEncryptionAlgorithm determines the algorithm used to encrypt a
+// content key. Change the value of this variable to change which
+// algorithm is used in the Encrypt() function.
+var KeyEncryptionAlgorithm = OIDEncryptionAlgorithmRSA
+
+// SignatureAlgorithm determines the algorithm used to sign the message.
+// Change the value of this variable to change which algorithm is used in
+// the PKCS7 Envelope signing
+var SignatureDigestAlgorithm = OIDDigestAlgorithmSHA256

--- a/defaults.go
+++ b/defaults.go
@@ -27,7 +27,7 @@ const (
 // ContentEncryptionAlgorithm determines the algorithm used to encrypt the
 // plaintext message. Change the value of this variable to change which
 // algorithm is used in the Encrypt() function.
-var ContentEncryptionAlgorithm = EncryptionAlgorithmAES256CBC
+var ContentEncryptionAlgorithm = EncryptionAlgorithmDESCBC
 
 // KeyEncryptionHash determines the crypto.Hash algorithm to use
 // when encrypting a content key. Change the value of this variable
@@ -42,4 +42,4 @@ var KeyEncryptionAlgorithm = OIDEncryptionAlgorithmRSA
 // SignatureAlgorithm determines the algorithm used to sign the message.
 // Change the value of this variable to change which algorithm is used in
 // the PKCS7 Envelope signing
-var SignatureDigestAlgorithm = OIDDigestAlgorithmSHA256
+var SignatureDigestAlgorithm = OIDDigestAlgorithmSHA1

--- a/defaults_fips.go
+++ b/defaults_fips.go
@@ -1,0 +1,45 @@
+//go:build requirefips
+// +build requirefips
+
+package pkcs7
+
+import "crypto"
+
+const (
+	// EncryptionAlgorithmDESCBC is the DES CBC encryption algorithm
+	EncryptionAlgorithmDESCBC = iota
+
+	// EncryptionAlgorithmAES128CBC is the AES 128 bits with CBC encryption algorithm
+	// Avoid this algorithm unless required for interoperability; use AES GCM instead.
+	EncryptionAlgorithmAES128CBC
+
+	// EncryptionAlgorithmAES256CBC is the AES 256 bits with CBC encryption algorithm
+	// Avoid this algorithm unless required for interoperability; use AES GCM instead.
+	EncryptionAlgorithmAES256CBC
+
+	// EncryptionAlgorithmAES128GCM is the AES 128 bits with GCM encryption algorithm
+	EncryptionAlgorithmAES128GCM
+
+	// EncryptionAlgorithmAES256GCM is the AES 256 bits with GCM encryption algorithm
+	EncryptionAlgorithmAES256GCM
+)
+
+// ContentEncryptionAlgorithm determines the algorithm used to encrypt the
+// plaintext message. Change the value of this variable to change which
+// algorithm is used in the Encrypt() function.
+var ContentEncryptionAlgorithm = EncryptionAlgorithmDESCBC
+
+// KeyEncryptionHash determines the crypto.Hash algorithm to use
+// when encrypting a content key. Change the value of this variable
+// to change which algorithm is used in the Encrypt() function.
+var KeyEncryptionHash = crypto.SHA256
+
+// KeyEncryptionAlgorithm determines the algorithm used to encrypt a
+// content key. Change the value of this variable to change which
+// algorithm is used in the Encrypt() function.
+var KeyEncryptionAlgorithm = OIDEncryptionAlgorithmRSA
+
+// SignatureAlgorithm determines the algorithm used to sign the message.
+// Change the value of this variable to change which algorithm is used in
+// the PKCS7 Envelope signing
+var SignatureDigestAlgorithm = OIDDigestAlgorithmSHA1

--- a/defaults_fips.go
+++ b/defaults_fips.go
@@ -37,7 +37,7 @@ var KeyEncryptionHash = crypto.SHA256
 // KeyEncryptionAlgorithm determines the algorithm used to encrypt a
 // content key. Change the value of this variable to change which
 // algorithm is used in the Encrypt() function.
-var KeyEncryptionAlgorithm = OIDEncryptionAlgorithmRSA
+var KeyEncryptionAlgorithm = OIDEncryptionAlgorithmRSAOAEP
 
 // SignatureAlgorithm determines the algorithm used to sign the message.
 // Change the value of this variable to change which algorithm is used in

--- a/defaults_fips.go
+++ b/defaults_fips.go
@@ -27,7 +27,7 @@ const (
 // ContentEncryptionAlgorithm determines the algorithm used to encrypt the
 // plaintext message. Change the value of this variable to change which
 // algorithm is used in the Encrypt() function.
-var ContentEncryptionAlgorithm = EncryptionAlgorithmDESCBC
+var ContentEncryptionAlgorithm = EncryptionAlgorithmAES256CBC
 
 // KeyEncryptionHash determines the crypto.Hash algorithm to use
 // when encrypting a content key. Change the value of this variable
@@ -42,4 +42,4 @@ var KeyEncryptionAlgorithm = OIDEncryptionAlgorithmRSA
 // SignatureAlgorithm determines the algorithm used to sign the message.
 // Change the value of this variable to change which algorithm is used in
 // the PKCS7 Envelope signing
-var SignatureDigestAlgorithm = OIDDigestAlgorithmSHA1
+var SignatureDigestAlgorithm = OIDDigestAlgorithmSHA256

--- a/encrypt.go
+++ b/encrypt.go
@@ -39,47 +39,13 @@ type encryptedContentInfo struct {
 	EncryptedContent           asn1.RawValue `asn1:"tag:0,optional"`
 }
 
-const (
-	// EncryptionAlgorithmDESCBC is the DES CBC encryption algorithm
-	EncryptionAlgorithmDESCBC = iota
-
-	// EncryptionAlgorithmAES128CBC is the AES 128 bits with CBC encryption algorithm
-	// Avoid this algorithm unless required for interoperability; use AES GCM instead.
-	EncryptionAlgorithmAES128CBC
-
-	// EncryptionAlgorithmAES256CBC is the AES 256 bits with CBC encryption algorithm
-	// Avoid this algorithm unless required for interoperability; use AES GCM instead.
-	EncryptionAlgorithmAES256CBC
-
-	// EncryptionAlgorithmAES128GCM is the AES 128 bits with GCM encryption algorithm
-	EncryptionAlgorithmAES128GCM
-
-	// EncryptionAlgorithmAES256GCM is the AES 256 bits with GCM encryption algorithm
-	EncryptionAlgorithmAES256GCM
-)
-
-// ContentEncryptionAlgorithm determines the algorithm used to encrypt the
-// plaintext message. Change the value of this variable to change which
-// algorithm is used in the Encrypt() function.
-var ContentEncryptionAlgorithm = EncryptionAlgorithmDESCBC
-
 // ErrUnsupportedEncryptionAlgorithm is returned when attempting to encrypt
 // content with an unsupported algorithm.
 var ErrUnsupportedEncryptionAlgorithm = errors.New("pkcs7: cannot encrypt content: only DES-CBC, AES-CBC, and AES-GCM supported")
 
-// KeyEncryptionAlgorithm determines the algorithm used to encrypt a
-// content key. Change the value of this variable to change which
-// algorithm is used in the Encrypt() function.
-var KeyEncryptionAlgorithm = OIDEncryptionAlgorithmRSA
-
 // ErrUnsupportedKeyEncryptionAlgorithm is returned when an
 // unsupported key encryption algorithm OID is provided.
 var ErrUnsupportedKeyEncryptionAlgorithm = errors.New("pkcs7: unsupported key encryption algorithm provided")
-
-// KeyEncryptionHash determines the crypto.Hash algorithm to use
-// when encrypting a content key. Change the value of this variable
-// to change which algorithm is used in the Encrypt() function.
-var KeyEncryptionHash = crypto.SHA256
 
 // ErrUnsupportedKeyEncryptionHash is returned when an
 // unsupported key encryption hash is provided.

--- a/sign.go
+++ b/sign.go
@@ -24,7 +24,7 @@ type SignedData struct {
 }
 
 // NewSignedData takes data and initializes a PKCS7 SignedData struct that is
-// ready to be signed via AddSigner. The digest algorithm is set to SHA1 by default
+// ready to be signed via AddSigner. The digest algorithm is set to SHA2-256 by default
 // and can be changed by calling SetDigestAlgorithm.
 func NewSignedData(data []byte) (*SignedData, error) {
 	content, err := asn1.Marshal(data)
@@ -39,7 +39,7 @@ func NewSignedData(data []byte) (*SignedData, error) {
 		ContentInfo: ci,
 		Version:     1,
 	}
-	return &SignedData{sd: sd, data: data, digestOid: OIDDigestAlgorithmSHA1}, nil
+	return &SignedData{sd: sd, data: data, digestOid: OIDDigestAlgorithmSHA256}, nil
 }
 
 // SignerInfoConfig are optional values to include when adding a signer

--- a/sign.go
+++ b/sign.go
@@ -24,8 +24,9 @@ type SignedData struct {
 }
 
 // NewSignedData takes data and initializes a PKCS7 SignedData struct that is
-// ready to be signed via AddSigner. The digest algorithm is set to SHA2-256 by default
-// and can be changed by calling SetDigestAlgorithm.
+// ready to be signed via AddSigner. The digest algorithm is set to SHA1 by default
+// and can be changed by calling SetDigestAlgorithm or overriding
+// the SignatureDigestAlgorithm package global variable
 func NewSignedData(data []byte) (*SignedData, error) {
 	content, err := asn1.Marshal(data)
 	if err != nil {
@@ -39,7 +40,7 @@ func NewSignedData(data []byte) (*SignedData, error) {
 		ContentInfo: ci,
 		Version:     1,
 	}
-	return &SignedData{sd: sd, data: data, digestOid: OIDDigestAlgorithmSHA256}, nil
+	return &SignedData{sd: sd, data: data, digestOid: SignatureDigestAlgorithm}, nil
 }
 
 // SignerInfoConfig are optional values to include when adding a signer

--- a/sign_test.go
+++ b/sign_test.go
@@ -243,7 +243,7 @@ func TestUnmarshalSignedAttribute(t *testing.T) {
 }
 
 func TestDegenerateCertificate(t *testing.T) {
-	cert, err := createTestCertificate(x509.SHA256WithRSA)
+	cert, err := createTestCertificate(x509.SHA1WithRSA)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sign_test.go
+++ b/sign_test.go
@@ -243,7 +243,7 @@ func TestUnmarshalSignedAttribute(t *testing.T) {
 }
 
 func TestDegenerateCertificate(t *testing.T) {
-	cert, err := createTestCertificate(x509.SHA1WithRSA)
+	cert, err := createTestCertificate(x509.SHA256WithRSA)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

Default Digest Update

#### Pain or issue this feature alleviates:

SHA1 is no longer allowed for signature digests under FIPS 140-3 and FIPS 140-2 goes end of life in 2026. Most cryptographic backends no longer allow the use of SHA1 as a digest (for example Go doesn't even allow it, it requires the ENV Variable). 

Allowing people to use and support SHA1 is fine, but it definitely should not be the default.

#### Why is this important to the project (if not answered above):

In the spirit of go - Defaults should be safe defaults. 

#### Is there documentation on how to use this feature? If so, where?

No functional change

#### In what environments or workflows is this feature supported?

SCEP is my main familiarity with PKCS7, but any PKCS7 usage with a signed envelope

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

Extremely legacy environments (i.e. pre-2003), however they can use the digest algorithm setter as documented. 

#### Supporting links/other PRs/issues:
https://github.com/smallstep/pkcs7/issues/27

Less configurable, but simpler approach than here:
https://github.com/smallstep/pkcs7/pull/29/files


💔Thank you!
