### PR TITLE
gh: forwarded codeql secrets through code-scan-cron.yml

### DIFF
--- a/.github/workflows/code-scan-cron.yml
+++ b/.github/workflows/code-scan-cron.yml
@@ -6,4 +6,9 @@ on:
 
 jobs:
   code-scan:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     uses: smallstep/workflows/.github/workflows/code-scan.yml@main
+    secrets: inherit


### PR DESCRIPTION
This PR restructures `code-scan-cron.yml` to grant the `code-scan` job `actions: read`, `contents: read`, and `security-events: write` (per-job), and adds `secrets: inherit` so CodeQL can fetch private modules — see smallstep/workflows#326.
