### PR TITLE
Repository housekeeping

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,10 +8,6 @@ insert_final_newline = true
 tab_width = unset
 trim_trailing_whitespace = true
 
-[*.{yml,yaml}]
-indent_size = 2
-indent_style = space
-
-[*.md]
+[*.{md,yml,yaml}]
 indent_size = 2
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = tab
+insert_final_newline = true
+tab_width = unset
+trim_trailing_whitespace = true
+
+[*.{yml,yaml}]
+indent_size = 2
+indent_style = space
+
+[*.md]
+indent_size = 2
+indent_style = space

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,32 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/" # Location of package manifests
+
+  - package-ecosystem: gomod
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      all:
+        patterns:
+        - "*"
+        update-types:
+        - minor
+        - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      all:
+        patterns:
+        - "*"
+        update-types:
+        - minor
+        - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,18 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    tags-ignore:
+      - '**'
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go: ['1.14', '1.15', '1.16', '1.21', '1.22', '1.23']
+        go: ['1.14', '1.15', '1.16', '1.21', '1.22', '1.23', '1.24', '1.25']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
         go: ['1.14', '1.15', '1.16', '1.21', '1.22', '1.23', '1.24', '1.25']
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
-    - uses: actions/setup-go@v4
+    - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version: ${{ matrix.go }}
     - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
   test:
     name: Test
     strategy:
+      fail-fast: false
       matrix:
         go: ['1.14', '1.15', '1.16', '1.21', '1.22', '1.23', '1.24', '1.25']
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.14', '1.15', '1.16', '1.21', '1.22', '1.23', '1.24', '1.25']
+        go: ['1.14', '1.15', '1.16', '1.21', '1.22', '1.23']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/code-scan-cron.yml
+++ b/.github/workflows/code-scan-cron.yml
@@ -12,3 +12,6 @@ jobs:
       security-events: write
     uses: smallstep/workflows/.github/workflows/code-scan.yml@main
     secrets: inherit
+    with:
+      codeql-build-mode: manual # tell codeql we'll build; skips autobuild's Makefile heuristic
+      codeql-build-cmd: go build ./...

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.1.1
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ import (
 	"fmt"
 	"os"
 
-    "github.com/smallstep/pkcs7"
+	"github.com/smallstep/pkcs7"
 )
 
 func SignAndDetach(content []byte, cert *x509.Certificate, privkey *rsa.PrivateKey) (signed []byte, err error) {


### PR DESCRIPTION
The weekly `Code Scan Cron` workflow has been failing since at least May: the shared `code-scan.yml` defaults CodeQL's build command to `V=1 make build`, and this repo's `Makefile` has no `build` target. This PR fixes that by telling CodeQL to build with a plain `go build ./...`, the same fix already in use in `backend`.

It also does some housekeeping: pins all actions to their current versions by checksum, stops CI from running twice for PRs, expands the `dependabot` config to also cover GitHub Actions, and adds an `.editorconfig` file.

Finally, no code is touched in this PR so there's no need for a new release.